### PR TITLE
Mock SCSI info in RSpec when running outside this cookbook

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,1 @@
-automatic_attrs['bus']['scsi'] = ::SCSI.devices(node) unless Chef::Config['bus_scsi_disabled']
+automatic_attrs['bus']['scsi'] = ::SCSI.devices(node)

--- a/libraries/_chefspec_patch.rb
+++ b/libraries/_chefspec_patch.rb
@@ -1,8 +1,0 @@
-if defined?(ChefSpec)
-  require 'chef/config'
-
-  if ::Chef::Config[:bus_scsi_disabled].nil?
-    ::Chef::Log.warn 'Disabling bus-scsi for ChefSpec'
-    ::Chef::Config[:bus_scsi_enabled] = true
-  end
-end

--- a/libraries/_test_patch.rb
+++ b/libraries/_test_patch.rb
@@ -1,0 +1,11 @@
+if defined?(ChefSpec) && ENV['MOCK_BUS_SCSI_INFO'] != 'NO'
+  require_relative 'default'
+
+  module SCSIPatch
+    def devices(_node)
+      ::Mash.new
+    end
+  end
+  ::Chef::Log.warn 'Patching SCSI module for ChefSpec'
+  ::SCSI.singleton_class.prepend(SCSIPatch)
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sre-core-infra@criteo.com'
 license          'Apache-2.0'
 description      'Pseudo-ohai for SCSI disks'
 long_description 'Pseudo-ohai for SCSI disks'
-version          '0.1.1'
+version          '0.1.2'
 
 supports         'centos',  '>= 6.0'
 supports         'redhat',  '>= 6.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,9 @@ require 'json'
 require 'chefspec'
 require 'chefspec/berkshelf'
 
+# Disable ::SCSI.devices mock
+ENV['MOCK_BUS_SCSI_INFO'] = 'NO'
+
 # Helper to get input/output test vectors
 SPEC_DATA_DIR = ::File.join(__dir__, 'data')
 def example_data(name)
@@ -12,7 +15,4 @@ end
 
 ::RSpec.configure do |config|
   ::Chef::Log.level(config.log_level = :fatal)
-  config.before do
-    ::Chef::Config[:bus_scsi_disabled] = false
-  end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -8,24 +8,11 @@
 require 'spec_helper'
 
 describe 'bus-scsi::default' do
-  context 'When all attributes are default, on centos 6.7' do
+  context 'When all attributes are default, on centos 7.5.1804' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(
         platform: 'centos',
-        version:  '6.7',
-      )
-      runner.converge(described_recipe)
-    end
-
-    it 'converges successfully' do
-      expect { chef_run }.to_not raise_error
-    end
-  end
-  context 'When all attributes are default, on centos 7.2.1511' do
-    let(:chef_run) do
-      runner = ChefSpec::SoloRunner.new(
-        platform: 'centos',
-        version:  '7.2.1511',
+        version:  '7.5.1804',
       )
       runner.converge(described_recipe)
     end


### PR DESCRIPTION
Previously, the value Chef::Config['bus_scsi_disabled'] was set when
running in an RSpec context. This was supposed to mock/disable the
setting of the 'bus-scsi' attributes to make unit test for recipes work.

But this was subject to load ordering issue and didn't really work in
the end (especially when this cookbook was a dependency in another
cookbook).

Let's rework the system with a real mock when run from another cookbook
and no mock when run here.