### PR TITLE
Require 'wmi-lite' only when really needed

### DIFF
--- a/libraries/windows.rb
+++ b/libraries/windows.rb
@@ -1,8 +1,8 @@
-require 'wmi-lite'
-
 module SCSI
   module Windows
     def self.scsi_devices
+      require 'wmi-lite'
+
       wmi = ::WmiLite::Wmi.new('root\CIMV2')
       wmi.instances_of('Win32_DiskDrive').reduce(::Mash.new) do |result, disk|
         host    = disk['scsibus']

--- a/spec/unit/libraries/windows_spec.rb
+++ b/spec/unit/libraries/windows_spec.rb
@@ -1,3 +1,4 @@
+require 'wmi-lite'
 require 'spec_helper'
 require_relative '../../../libraries/windows.rb'
 


### PR DESCRIPTION
All Ruby files in libraries/ are loaded during Chef's compile phase. It
means that we require 'wmi-lite', an almost Windows only gem, even on
other platforms. This is not needed and may even be harmful in some
situations.

Let's play nicer and defer the inclusion to the function body where it
is really needed.