### PR TITLE
Make operations on Win32_DiskDrive properties safer

### DIFF
--- a/libraries/windows.rb
+++ b/libraries/windows.rb
@@ -18,10 +18,10 @@ module SCSI
           channel: disk['scsiport'],
           target:  disk['scsitargetid'],
           lun:     disk['scsilogicalunit'],
-          model:   disk['model'].strip,
-          fwrev:   disk['firmwarerevision'].strip,
-          serial:  disk['serialnumber'].strip,
-          size:    disk['size'].to_i,
+          model:   disk['model']&.strip,
+          fwrev:   disk['firmwarerevision']&.strip,
+          serial:  disk['serialnumber']&.strip,
+          size:    disk['size']&.to_i,
         ),)
       end
     end


### PR DESCRIPTION
In some case, a disk doesn't have all its information exposed (this
probable happens when running in a virtual machines). This is an issue
since we try to use the .strip() method on some of those properties.

Let's use the safe navigation operator to ensure this won't trigger an
exception.